### PR TITLE
UI updates

### DIFF
--- a/modern/src/main/MainToolbar.js
+++ b/modern/src/main/MainToolbar.js
@@ -25,6 +25,22 @@ const useStyles = makeStyles((theme) => ({
     gap: theme.spacing(2),
     width: theme.dimensions.drawerWidthTablet,
   },
+  selectAll: {
+    fontSize: '12px',
+    fontWeight: 400,
+  },
+  rowC: {
+    display: 'flex',
+    flexDirection: 'row',
+    width: '100%',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  dropdownText: {
+    display: 'flex',
+    flexDirection: 'row',
+    flexGrow: 1,
+  },
 }));
 
 const MainToolbar = ({
@@ -56,6 +72,8 @@ const MainToolbar = ({
   const [filterAnchorEl, setFilterAnchorEl] = useState(null);
   const [devicesAnchorEl, setDevicesAnchorEl] = useState(null);
 
+  const [isGroupsSelectAll, setIsGroupsSelectAll] = useState(false);
+
   const deviceStatusCount = (status) => Object.values(devices).filter((d) => d.status === status).length;
   const deviceMovingCount = (status) => {
     if (status === 'all') return Object.values(devices).length;
@@ -68,6 +86,42 @@ const MainToolbar = ({
       return !p.attributes || p.attributes.motion === false;
     }).length;
   };
+
+  /// Function to handle changes made to Groups dropdown by the user.
+  function handleChangeInGroupSelect(e) {
+    // Check the current event item's target's value.
+    // if it contains 'all' user has clicked on select all option.
+    // if not then user has clicked on something else.
+    if (e.target.value.includes('all')) {
+      // Check if select all is already tapped
+      //  if true => `unselect all` action should be performed.
+      //  if false => `select all` action should be performed.
+      if (isGroupsSelectAll) {
+        // unselect all case.
+        setFilter({ ...filter, groups: [] });
+        // setting state to false ==> unselect done.
+        setIsGroupsSelectAll(false);
+        return;
+      }
+
+      // select all case.
+      const ids = [];
+      Object.keys(groups).forEach((d) => ids.push(groups[d].id));
+      setFilter({ ...filter, groups: ids });
+      setIsGroupsSelectAll(true);
+      return;
+    }
+
+    setFilter({ ...filter, groups: e.target.value });
+
+    setIsGroupsSelectAll(false);
+  }
+
+  function renderValueForGroupsDropdown(e) {
+    let items = Object.values(groups).filter((g) => e.includes(g.id));
+    items = items.map((i) => (items.indexOf(i) !== items.length - 1 ? `${i.name}, ` : i.name));
+    return items;
+  }
 
   return (
     <Toolbar ref={toolbarRef} className={classes.toolbar}>
@@ -161,12 +215,28 @@ const MainToolbar = ({
             <Select
               label={t('settingsGroups')}
               value={filter.groups}
-              onChange={(e) => setFilter({ ...filter, groups: e.target.value })}
+              // onChange={(e) => setFilter({ ...filter, groups: e.target.value })}
+              onChange={(e) => handleChangeInGroupSelect(e)}
+              renderValue={(e) => renderValueForGroupsDropdown(e)}
               multiple
             >
+              <MenuItem key="all" value="all" className={classes.selectAll}>
+                {isGroupsSelectAll ? 'Unselect All' : 'Select All'}
+              </MenuItem>
+
               {Object.values(groups).sort((a, b) => a.name.localeCompare(b.name)).map((group) => (
-                <MenuItem key={group.id} value={group.id}>{group.name}</MenuItem>
+                <MenuItem key={group.id} value={group.id}>
+                  <div className={classes.rowC}>
+                    <Checkbox checked={filter.groups.includes(group.id)} />
+                    <div className={classes.dropdownText}>
+                      {group.name}
+                    </div>
+                  </div>
+                </MenuItem>
               ))}
+              {/* {Object.values(groups).sort((a, b) => a.name.localeCompare(b.name)).map((group) => (
+                <MenuItem key={group.id} value={group.id}>{group.name}</MenuItem>
+              ))} */}
             </Select>
           </FormControl>
           <FormControl>

--- a/modern/src/reports/TripReportPage.js
+++ b/modern/src/reports/TripReportPage.js
@@ -94,8 +94,9 @@ const TripReportPage = () => {
     }
   }, [selectedItem]);
 
-  const handleSubmit = useCatch(async ({ deviceIds, from, to, type }) => {
+  const handleSubmit = useCatch(async ({ deviceIds, groupIds, from, to, type }) => {
     const query = new URLSearchParams({ from, to });
+    groupIds.forEach((groupId) => query.append('groupId', groupId));
     deviceIds.forEach((deviceId) => query.append('deviceId', deviceId));
     if (type === 'export') {
       window.location.assign(`/api/reports/trips/xlsx?${query.toString()}`);
@@ -175,7 +176,7 @@ const TripReportPage = () => {
         )}
         <div className={classes.containerMain}>
           <div className={classes.header}>
-            <ReportFilter handleSubmit={handleSubmit} handleSchedule={handleSchedule} multiDevice>
+            <ReportFilter handleSubmit={handleSubmit} handleSchedule={handleSchedule} multiDevice includeGroups>
               <ColumnSelect columns={columns} setColumns={setColumns} columnsArray={columnsArray} />
             </ReportFilter>
           </div>

--- a/modern/src/reports/components/ReportFilter.js
+++ b/modern/src/reports/components/ReportFilter.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 import React, { useState } from 'react';
 import {
   FormControl, InputLabel, Select, MenuItem, Button, TextField, Typography, Checkbox, Snackbar, Alert,
@@ -43,6 +44,8 @@ const ReportFilter = ({ children, handleSubmit, handleSchedule, showOnly, ignore
 
   const [snackbarMessage, setSnackbarMessage] = useState('');
 
+  const [snackbarSeverity, setSnackbarSeverity] = useState('');
+
   const [isExportDisable, setIsExportDisable] = useState(false);
 
   const vertical = 'top';
@@ -56,7 +59,8 @@ const ReportFilter = ({ children, handleSubmit, handleSchedule, showOnly, ignore
 
   const disableAfterExport = () => {
     setIsExportDisable(true);
-    setSnackbarMessage('Email has been requested and it will be delivered between 5-30 minutes from now.');
+    setSnackbarMessage('Report email has been requested and it will be delivered between 5-30 minutes from now. \n \n \n Note: Do NOT request report email once again. Please wait for the current request report to be delivered.');
+    setSnackbarSeverity('success');
     setIsShowErrorSnackbar(true);
     timer = setTimeout(() => {
       setIsExportDisable(false);
@@ -107,7 +111,8 @@ const ReportFilter = ({ children, handleSubmit, handleSchedule, showOnly, ignore
       }
       if (selectedTo.diff(selectedFrom, 'minutes') > 10080) {
         // show snackbar.
-        setSnackbarMessage('Difference between from and to dates should be less than a week.');
+        setSnackbarMessage('Difference between from and to dates should be less than one week.');
+        setSnackbarSeverity('warning');
         setIsShowErrorSnackbar(true);
         return;
       }
@@ -191,6 +196,12 @@ const ReportFilter = ({ children, handleSubmit, handleSchedule, showOnly, ignore
     setIsGroupsSelectAll(false);
   }
 
+  // eslint-disable-next-line no-unused-vars, arrow-body-style
+  const snackbarMessageData = () => {
+    // eslint-disable-next-line react/no-danger
+    return (<p dangerouslySetInnerHTML={snackbarMessage} />);
+  };
+
   function renderValueForDevicesDropdown(e) {
     let items = Object.values(devices).filter((d) => e.includes(d.id));
     items = items.map((i) => (items.indexOf(i) !== items.length - 1 ? `${i.name}, ` : i.name));
@@ -214,7 +225,7 @@ const ReportFilter = ({ children, handleSubmit, handleSchedule, showOnly, ignore
             autoHideDuration={15000}
             ClickAwayListenerProps={{ onClickAway: () => null }}
           >
-            <Alert onClose={snackbarClose} severity="warning" sx={{ width: '100%' }}>
+            <Alert onClose={snackbarClose} severity={snackbarSeverity} sx={{ width: '100%' }}>
               {snackbarMessage}
             </Alert>
           </Snackbar>
@@ -255,12 +266,24 @@ const ReportFilter = ({ children, handleSubmit, handleSchedule, showOnly, ignore
           <FormControl fullWidth>
             <InputLabel>{t('settingsGroups')}</InputLabel>
             {/* <Autocomplete
+              disablePortal
               multiple
-              label={t('settingsGroups')}
-              // value={groupIds}
-              options={['1', '2', '3']}
-              values={['1', '2', '3']}
-              getOptionLabel={(option) => option.title}
+              // label={t('settingsGroups')}
+              // values={groupIds}
+              value={groupIds}
+              options={Object.values(groups).map((g) => g.name)}
+              // options={Object.values(groups).sort((a, b) => a.name.localeCompare(b.name)).map((group) => (
+              //   <MenuItem key={group.id} value={group.id}>
+              //     <div className={classes.rowC}>
+              //       <Checkbox checked={groupIds?.indexOf(group.id) > -1} />
+              //       <div className={classes.dropdownText}>
+              //         {group.name}
+              //       </div>
+              //     </div>
+              //   </MenuItem>
+              // ))}
+              // options={['1', '2', '3']}
+              // values={['1', '2', '3']}
               filterSelectedOptions
               onChange={(e) => handleChangeInGroupSelect(e)}
               renderInput={(params) => (
@@ -285,6 +308,7 @@ const ReportFilter = ({ children, handleSubmit, handleSchedule, showOnly, ignore
                 </MenuItem>
               ))}
             </Autocomplete> */}
+
             <Select
               label={t('settingsGroups')}
               value={groupIds}

--- a/modern/src/reports/components/ReportFilter.js
+++ b/modern/src/reports/components/ReportFilter.js
@@ -262,6 +262,7 @@ const ReportFilter = ({ children, handleSubmit, handleSchedule, showOnly, ignore
                   });
                   return n ?? option.name;
                 }}
+                limitTags={1}
                 disableCloseOnSelect
                 value={multiDevice ? deviceIds : deviceId}
                 onChange={(e, v, r, d) => handleChangeInDeviceSelect(v)}
@@ -270,20 +271,18 @@ const ReportFilter = ({ children, handleSubmit, handleSchedule, showOnly, ignore
 
                     {(device.id === -999 && multiDevice) ?
                       (
-                        <MenuItem className={classes.selectAll}>
+                        <div className={classes.selectAll}>
                           {isDevicesSelectAll ? 'Unselect All' : 'Select All'}
-                        </MenuItem>
+                        </div>
                       )
                       :
                       (
-                        <MenuItem>
-                          <div className={classes.rowC}>
-                            <Checkbox checked={multiDevice ? (deviceIds.includes(device.id)) : (deviceId === device.id)} />
-                            <div className={classes.dropdownText}>
-                              {device.name}
-                            </div>
+                        <div className={classes.rowC}>
+                          <Checkbox size="small" checked={multiDevice ? (deviceIds.includes(device.id)) : (deviceId === device.id)} />
+                          <div className={classes.dropdownText}>
+                            {device.name}
                           </div>
-                        </MenuItem>
+                        </div>
                       )}
                   </li>
                 )}
@@ -301,14 +300,14 @@ const ReportFilter = ({ children, handleSubmit, handleSchedule, showOnly, ignore
               >
 
                 {Object.values(devices).sort((a, b) => a.name.localeCompare(b.name)).map((device) => (
-                  <MenuItem key={device.id} value={device.id}>
-                    <div className={classes.rowC}>
-                      {multiDevice ? (<Checkbox checked={deviceIds?.indexOf(device.id) > -1} />) : null}
-                      <div className={classes.dropdownText}>
-                        {device.name}
-                      </div>
+
+                  <div className={classes.rowC}>
+                    {multiDevice ? (<Checkbox checked={deviceIds?.indexOf(device.id) > -1} />) : null}
+                    <div className={classes.dropdownText}>
+                      {device.name}
                     </div>
-                  </MenuItem>
+                  </div>
+
                 ))}
               </Select>
             )}
@@ -324,6 +323,8 @@ const ReportFilter = ({ children, handleSubmit, handleSchedule, showOnly, ignore
               multiple
               id="select-groups"
               options={[{ name: 'select all', id: -999 }, ...Object.values(groups)]}
+              size="small"
+              limitTags={1}
               getOptionLabel={(option) => {
                 let n;
                 Object.values(groups).forEach((e) => {
@@ -340,20 +341,18 @@ const ReportFilter = ({ children, handleSubmit, handleSchedule, showOnly, ignore
                 <li {...props}>
                   {group.id === -999 ?
                     (
-                      <MenuItem className={classes.selectAll}>
+                      <div className={classes.selectAll}>
                         {isGroupsSelectAll ? 'Unselect All' : 'Select All'}
-                      </MenuItem>
+                      </div>
                     )
                     :
                     (
-                      <MenuItem>
-                        <div className={classes.rowC}>
-                          <Checkbox checked={groupIds.includes(group.id)} />
-                          <div className={classes.dropdownText}>
-                            {group.name}
-                          </div>
+                      <div className={classes.rowC}>
+                        <Checkbox size="small" checked={groupIds.includes(group.id)} />
+                        <div className={classes.dropdownText}>
+                          {group.name}
                         </div>
-                      </MenuItem>
+                      </div>
                     )}
                 </li>
               )}

--- a/modern/src/store/reports.js
+++ b/modern/src/store/reports.js
@@ -8,7 +8,8 @@ const { reducer, actions } = createSlice({
     period: 'today',
     from: moment().subtract(1, 'hour').locale('en').format(moment.HTML5_FMT.DATETIME_LOCAL),
     to: moment().locale('en').format(moment.HTML5_FMT.DATETIME_LOCAL),
-    button: 'json',
+    // Set mail to be the default filter action.
+    button: 'mail',
   },
   reducers: {
     updateGroupIds(state, action) {


### PR DESCRIPTION
- Email is the default selected report option. (Previously it was 'Show').
- `This Month` and `Previous Month` filter options removed.
- Date filter range check added, if the range selected is more than a week into past, filter is not applied.
- Report button is disabled for 30 seconds after the report is requested once.
- A warning and info snackbars are added to notify users not to request email very quickly and to select proper date filter range.
- Dropdowns for devices and groups (in reports) now have a searchable dropdown with multi-select and checkboxes.
- Groups are added to filters in trips report.